### PR TITLE
Fix the line that modifies the agents' local view

### DIFF
--- a/src/main/scala/agents/QueenAgent.scala
+++ b/src/main/scala/agents/QueenAgent.scala
@@ -312,7 +312,7 @@ object QueenAgent {
           nogood.positions
             .foldLeft(queenState.addNogood(nogood)) {
               case (acc, (queenId, colVal)) =>
-                if (!acc.neighbours.contains(queenId)) {
+                if (!acc.agentView.contains(queenId)) {
                   //                  queenRegistry(queenId) ! QueenMessageAddLink(currentRow)
                   acc
                     .changeAgentValue(queenId, colVal)


### PR DESCRIPTION
After receiving a Nogood, the agents would attempt to change their local view to
the values from the Nogood. As a result, considering that it is always the agent
with the lowest priority from the Nogood that receives it, the agent would almost
always have a local view compatible with the Nogood received.

This answer led to another question: Why were there cases when an agent received a
Nogood, but it did not state to be compatible with it?